### PR TITLE
fix: remove double period in 2058 rules text

### DIFF
--- a/2048 Power Compendium.js
+++ b/2048 Power Compendium.js
@@ -13211,7 +13211,7 @@ function gmDisplayVars() {
         else {
             document.getElementById("2058_disappearingMerges_text").innerHTML = "Tiles with a base too big cannot be created."
             document.getElementById("2058_disappearingMerges_text").style.setProperty("color", "#812c81");
-            disappearString = "that merge does not occur.";
+            disappearString = "that merge does not occur";
         }
         if (mode_vars[0] == 0) {
             document.getElementById("2058_powRequired_counter").innerHTML = "n";


### PR DESCRIPTION
## Summary
Fixes a typo where the 2058 n^n version rules text displayed a double period:

**Before:** \&quot;...then that merge does not occur..\&quot;  
**After:** \&quot;...then that merge does not occur.\&quot;

The issue was that `disappearString` already included a trailing period, and the template string appended another one.

**Root cause:** In `2048 Power Compendium.js` line 13214, `disappearString` was set to `\&quot;that merge does not occur.\&quot;` (with period), but the template at line 13221 already added `.` after the variable: `then ${disappearString}.`

Fixes [issue #8](https://github.com/MathCookie17/The-2048-Power-Compendium/issues/8).